### PR TITLE
Strip non-numbers from PIN input

### DIFF
--- a/src/Leaderboard.js
+++ b/src/Leaderboard.js
@@ -94,7 +94,7 @@ class Linktoindividual extends React.Component {
                 placeholder="PIN on Quercus"
                 aria-label="PIN"
                 aria-describedby="basic-addon2"
-                onChange={e => this.setState({ studentPIN: e.target.value })}
+                onChange={e => this.setState({ studentPIN: e.target.value.replace(/\D/g, '') })}
               />
             </InputGroup>
           </Col>


### PR DESCRIPTION
In Quercus, the PIN numbers are shown as numeric grades, ex. `123,456 / 0`. However, copying and pasting the 'grade' directly into the leaderboard will cause an Access Denied error, because the comma is not part of the PIN. A mild inconvenience for sure, but easy enough to fix. 

This PR adds a simple regex filter to only read numbers from the PIN field, therefore removing the problematic periods and commas. It is now possible to just copy and paste the Quercus 'grade' without modifications. 